### PR TITLE
DE7889 Invalid Redirects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    netlify-redirector (0.0.1)
+    netlify-redirector (0.0.2)
       activesupport
       colorize
       rake
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -18,7 +18,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     coderay (1.1.2)
     colorize (0.8.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     ffi (1.9.25)
     formatador (0.2.5)
@@ -36,7 +36,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    i18n (1.1.1)
+    i18n (1.8.4)
       concurrent-ruby (~> 1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -46,7 +46,7 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.9.0)
-    minitest (5.11.3)
+    minitest (5.14.1)
     nenv (0.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -76,7 +76,7 @@ GEM
     shellany (0.0.1)
     thor (0.20.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -91,4 +91,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.16.3
+   2.1.4

--- a/lib/netlify-redirector/redirect.rb
+++ b/lib/netlify-redirector/redirect.rb
@@ -9,7 +9,11 @@ module NetlifyRedirector
     def to_s
       path = self.class.replace(@path)
       dest = self.class.replace(@dest)
-      "#{path}\t#{dest}\t#{@status}"
+      if path === dest
+        "#{path}\t#{@status}"
+      else
+        "#{path}\t#{dest}\t#{@status}"
+      end
     end
 
     def context_included?

--- a/lib/netlify-redirector/version.rb
+++ b/lib/netlify-redirector/version.rb
@@ -1,3 +1,3 @@
 module NetlifyRedirector
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/spec/netlify-redirector/redirect_spec.rb
+++ b/spec/netlify-redirector/redirect_spec.rb
@@ -74,4 +74,10 @@ describe NetlifyRedirector::Redirect do
     expect(@redirect.context_included?).to be_falsey
   end
 
+  it 'should abbreviate rules where path and destination are identical' do
+    src = "collegecamp/prepaidregistrationconfirmation/,collegecamp/prepaidregistrationconfirmation/,200! Role=user".split(',')
+    @redirect = NetlifyRedirector::Redirect.new(src)
+    expect(@redirect.to_s).to eq("collegecamp/prepaidregistrationconfirmation/\t200! Role=user")
+  end
+
 end


### PR DESCRIPTION
Netlify is reporting invalid redirect rules whenever the path & destination values are identical. 

> I do see a warning where you have 4 invalid rules. Specifically:
> 
> collegecamp/prepaidregistrationconfirmation/ collegecamp/prepaidregistrationconfirmation/ 200! Role=user
> manvetcamp/prepaidregistrationconfirmation manvetcamp/prepaidregistrationconfirmation 200! Role=user
> couplescamp/prepaidregistrationconfirmation/ couplescamp/prepaidregistrationconfirmation/ 200! Role=user
> uptownleaderaccelerator uptownleaderaccelerator 200! Role=user
> 
> You'll want to change those rules to look like the following:
> 
> collegecamp/prepaidregistrationconfirmation/ 200! Role=user
> 
> Note that there isn't a 'to' attribute in that rule since you aren't redirecting to another path. 

This PR updates the redirector library which is responsible for writing the `_redirects` file during each build to better handle these use-cases. 