### PR TITLE
Revert "DE7889 Invalid Redirects"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    netlify-redirector (0.0.2)
+    netlify-redirector (0.0.1)
       activesupport
       colorize
       rake
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.3)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -18,7 +18,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     coderay (1.1.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     ffi (1.9.25)
     formatador (0.2.5)
@@ -36,7 +36,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    i18n (1.8.4)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -46,7 +46,7 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.9.0)
-    minitest (5.14.1)
+    minitest (5.11.3)
     nenv (0.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -76,7 +76,7 @@ GEM
     shellany (0.0.1)
     thor (0.20.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.7)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -91,4 +91,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.1.4
+   1.16.3

--- a/lib/netlify-redirector/redirect.rb
+++ b/lib/netlify-redirector/redirect.rb
@@ -9,11 +9,7 @@ module NetlifyRedirector
     def to_s
       path = self.class.replace(@path)
       dest = self.class.replace(@dest)
-      if path === dest
-        "#{path}\t#{@status}"
-      else
-        "#{path}\t#{dest}\t#{@status}"
-      end
+      "#{path}\t#{dest}\t#{@status}"
     end
 
     def context_included?

--- a/lib/netlify-redirector/version.rb
+++ b/lib/netlify-redirector/version.rb
@@ -1,3 +1,3 @@
 module NetlifyRedirector
-  VERSION = "0.0.2"
+  VERSION = "0.0.1"
 end

--- a/spec/netlify-redirector/redirect_spec.rb
+++ b/spec/netlify-redirector/redirect_spec.rb
@@ -74,10 +74,4 @@ describe NetlifyRedirector::Redirect do
     expect(@redirect.context_included?).to be_falsey
   end
 
-  it 'should abbreviate rules where path and destination are identical' do
-    src = "collegecamp/prepaidregistrationconfirmation/,collegecamp/prepaidregistrationconfirmation/,200! Role=user".split(',')
-    @redirect = NetlifyRedirector::Redirect.new(src)
-    expect(@redirect.to_s).to eq("collegecamp/prepaidregistrationconfirmation/\t200! Role=user")
-  end
-
 end


### PR DESCRIPTION
Reverts crdschurch/netlify-redirector#3

This PR was created based on guidance from the Netlify support team. It appears that they were incorrect, as their tool doesn't support this syntax. I believe the source of the invalid redirect errors is related to the lack of a preceding forward-slash instead. 

![Screen Shot 2020-07-21 at 11 16 47 AM](https://user-images.githubusercontent.com/50378/88073226-f3197280-cb43-11ea-95de-57044fbb88d8.png)
