### PR TITLE
DE7889 Invalid Redirects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    netlify-redirector (0.0.2)
+    netlify-redirector (0.0.3)
       activesupport
       colorize
       rake

--- a/lib/netlify-redirector/redirect.rb
+++ b/lib/netlify-redirector/redirect.rb
@@ -10,9 +10,17 @@ module NetlifyRedirector
       path = self.class.replace(@path)
       dest = self.class.replace(@dest)
       if path === dest
-        "#{path}\t#{@status}"
+        "#{with_slash(path)}\t#{@status}"
       else
-        "#{path}\t#{dest}\t#{@status}"
+        "#{with_slash(path)}\t#{with_slash(dest)}\t#{@status}"
+      end
+    end
+
+    def with_slash(str)
+      if str.is_a?(String) && ! %w(http: https ${env).include?(str[0..4])
+        str[0] != '/' ? "/#{str}" : str
+      else
+        str
       end
     end
 

--- a/lib/netlify-redirector/version.rb
+++ b/lib/netlify-redirector/version.rb
@@ -1,3 +1,3 @@
 module NetlifyRedirector
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/netlify-redirector/redirect_spec.rb
+++ b/spec/netlify-redirector/redirect_spec.rb
@@ -77,7 +77,18 @@ describe NetlifyRedirector::Redirect do
   it 'should abbreviate rules where path and destination are identical' do
     src = "collegecamp/prepaidregistrationconfirmation/,collegecamp/prepaidregistrationconfirmation/,200! Role=user".split(',')
     @redirect = NetlifyRedirector::Redirect.new(src)
-    expect(@redirect.to_s).to eq("collegecamp/prepaidregistrationconfirmation/\t200! Role=user")
+    expect(@redirect.to_s).to eq("/collegecamp/prepaidregistrationconfirmation/\t200! Role=user")
+  end
+
+  it 'should prepend slashes to paths, as needed' do
+    @redirect = NetlifyRedirector::Redirect.new("undivided-training,http://undivided.com,200!".split(','))
+    expect(@redirect.to_s).to eq("/undivided-training\thttp://undivided.com\t200!")
+
+    @redirect = NetlifyRedirector::Redirect.new("undivided-training,undivided,200!".split(','))
+    expect(@redirect.to_s).to eq("/undivided-training\t/undivided\t200!")
+
+    @redirect = NetlifyRedirector::Redirect.new("http://www.crossroads.net/undivided,https://www.crossroads.net/undivided,200!".split(','))
+    expect(@redirect.to_s).to eq("http://www.crossroads.net/undivided\thttps://www.crossroads.net/undivided\t200!")
   end
 
 end


### PR DESCRIPTION
This PR ensures that all paths not starting w/ 'http' will be prepended with forward-slashes. 